### PR TITLE
Fix script auto-execution in dilate_mito

### DIFF
--- a/Mito/dilatie_mito.py
+++ b/Mito/dilatie_mito.py
@@ -66,4 +66,6 @@ def dilate_mito(mito_path, output_path, dilate_type='ball', dilate_size=3):
 
 mito_path = f'/media/liushuo/data1/data/synapse_seg/p545/mito/p545_mito_dilated.mrc'
 output_path = f'/media/liushuo/data1/data/synapse_seg/p545/mito/p545_mito_label.mrc'
-dilate_mito(mito_path, output_path, dilate_type='cube', dilate_size=5)
+
+if __name__ == "__main__":
+    dilate_mito(mito_path, output_path, dilate_type='cube', dilate_size=5)


### PR DESCRIPTION
## Summary
- prevent Mito/dilatie_mito.py from running automatically on import

## Testing
- `python -m py_compile Mito/dilatie_mito.py`
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_68677703249c8330aa0af31e536e4273